### PR TITLE
syntax

### DIFF
--- a/inst/css/code.css
+++ b/inst/css/code.css
@@ -110,3 +110,68 @@ h3 code {
     line-height: 1em;
     font-weight: 500;
 }
+
+code.sourceCode > span { display: inline-block; line-height: 1rem; }
+code.sourceCode > span { color: inherit; text-decoration: inherit; background: #f8f8f8; }
+code.sourceCode > span:empty { height: 1.2em; }
+.sourceCode { overflow: visible; }
+code.sourceCode { white-space: pre; position: relative; }
+div.sourceCode { margin: 1em 0; }
+pre.sourceCode { margin: 0; }
+@media screen {
+div.sourceCode { overflow: auto; }
+}
+@media print {
+code.sourceCode { white-space: pre-wrap; }
+code.sourceCode > span { text-indent: -5em; padding-left: 5em; }
+}
+pre.numberSource code
+  { counter-reset: source-line 0; }
+pre.numberSource code > span
+  { position: relative; left: -4em; counter-increment: source-line; }
+pre.numberSource code > span > a:first-child::before
+  { content: counter(source-line);
+    position: relative; left: -1em; text-align: right; vertical-align: baseline;
+    border: none; display: inline-block;
+    -webkit-touch-callout: none; -webkit-user-select: none;
+    -khtml-user-select: none; -moz-user-select: none;
+    -ms-user-select: none; user-select: none;
+    padding: 0 4px; width: 4em;
+    color: #aaaaaa;
+  }
+pre.numberSource { margin-left: 3em; border-left: 1px solid #aaaaaa;  padding-left: 4px; }
+div.sourceCode
+  {   }
+@media screen {
+code.sourceCode > span > a:first-child::before { text-decoration: underline; }
+}
+code span.al { color: #ff0000; font-weight: bold; } /* Alert */
+code span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
+code span.at { color: #7d9029; } /* Attribute */
+code span.bn { color: #40a070; } /* BaseN */
+code span.bu { } /* BuiltIn */
+code span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
+code span.ch { color: #4070a0; } /* Char */
+code span.cn { color: #880000; } /* Constant */
+code span.co { color: #60a0b0; font-style: italic; } /* Comment */
+code span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } /* CommentVar */
+code span.do { color: #ba2121; font-style: italic; } /* Documentation */
+code span.dt { color: #902000; } /* DataType */
+code span.dv { color: #40a070; } /* DecVal */
+code span.er { color: #ff0000; font-weight: bold; } /* Error */
+code span.ex { } /* Extension */
+code span.fl { color: #40a070; } /* Float */
+code span.fu { color: #06287e; } /* Function */
+code span.im { } /* Import */
+code span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
+code span.kw { color: #007020; font-weight: bold; } /* Keyword */
+code span.op { color: #666666; } /* Operator */
+code span.ot { color: #007020; } /* Other */
+code span.pp { color: #bc7a00; } /* Preprocessor */
+code span.sc { color: #4070a0; } /* SpecialChar */
+code span.ss { color: #bb6688; } /* SpecialString */
+code span.st { color: #4070a0; } /* String */
+code span.va { color: #19177c; } /* Variable */
+code span.vs { color: #4070a0; } /* VerbatimString */
+code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warning */
+/* Background */ pre .sourceCode {background-color: #f8f8f8; border: solid gray 1px; display:inline-block; padding:1rem}

--- a/inst/post-example3/index.Rmd
+++ b/inst/post-example3/index.Rmd
@@ -17,3 +17,22 @@ knitr::opts_chunk$set(echo = TRUE)
 
 blablabla
 lalalala
+
+```yaml
+---
+title: "RMarkdown to WordPress with goodpress"
+date: "2020-06-25T00:00:00"
+output: hugodown::md_document
+status: "publish"
+slug: "rmarkdown-wordpress-goodpress"
+categories: R Programming
+tags:
+  - R Markdown
+  - goodpress
+  - WordPress
+---
+```
+
+```{r, eval = FALSE}
+ggplot2::ggplot()
+```

--- a/inst/post-example3/index.md
+++ b/inst/post-example3/index.md
@@ -9,9 +9,30 @@ tags:
   - R Markdown
   - goodpress
   - WordPress
-rmd_hash: c822650eb6af8f11
+rmd_hash: 333f55d23a84d771
 
 ---
 
 blablabla lalalala
+
+``` yaml
+---
+title: "RMarkdown to WordPress with goodpress"
+date: "2020-06-25T00:00:00"
+output: hugodown::md_document
+status: "publish"
+slug: "rmarkdown-wordpress-goodpress"
+categories: R Programming
+tags:
+  - R Markdown
+  - goodpress
+  - WordPress
+---
+```
+
+<div class="highlight">
+
+<pre class='chroma'><code class='language-r' data-lang='r'><span class='k'>ggplot2</span>::<span class='nf'><a href='https://ggplot2.tidyverse.org/reference/ggplot.html'>ggplot</a></span>()</code></pre>
+
+</div>
 


### PR DESCRIPTION
cf #1 

If I add the CSS in this PR to my website (that I copy-pasted from self-contained HTML generated by Pandoc + a few tweaks to get the background) the YAML block gets highlighted.

Pandoc generate div and spans for all languages except R.

Ideally I'd like to find a way to produce HTML with inline styling this way no need to add CSS in the website (less efforts, and some users can't even add custom CSS anyway). Then the user could either use the CSS coming with this package or supply the path to their own stylesheet as argument. There could also be an option turning off inline styling (in favor of classes + CSS stylesheet).