### PR TITLE
optimize rmarkdown template

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -22,10 +22,6 @@ jobs:
           - {os: macOS-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
           - {os: ubuntu-16.04,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
-          - {os: ubuntu-16.04,   r: 'oldrel',  rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
-          - {os: ubuntu-16.04,   r: '3.5',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
-          - {os: ubuntu-16.04,   r: '3.4',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
-          - {os: ubuntu-16.04,   r: '3.3',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,6 +40,8 @@ Suggests:
     vcr
 VignetteBuilder: 
     knitr
+Depends: 
+    R (>= 3.6.0)
 Remotes:
     r-lib/hugodown,
     ropensci/vcr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,8 @@ VignetteBuilder:
     knitr
 Remotes:
     r-lib/hugodown,
-    ropensci/vcr
+    ropensci/vcr,
+    hrbrmstr/slugify
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,8 @@ Imports:
     utils,
     withr,
     xml2,
-    yaml
+    yaml,
+    slugify
 Suggests: 
     covr,
     fs,

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -25,8 +25,10 @@ read_more <- function() {
 #' @export
 #'
 #' @examples
+#' \dontrun{
 #' wordpress_url <- "https://rmd-wordpress.eu" # replace with your own (test) website
 #' wp_categories(wordpress_url)
+#' }
 wp_categories <- function(wordpress_url) {
   if (is.null(wordpress_url)) {
     stop("wordpress_url is missing")
@@ -45,8 +47,10 @@ wp_categories <- function(wordpress_url) {
 #' @export
 #'
 #' @examples
+#' \dontrun{
 #' wordpress_url <- "https://rmd-wordpress.eu" # replace with your own (test) website
 #' wp_tags(wordpress_url)
+#' }
 wp_tags <- function(wordpress_url) {
   if (is.null(wordpress_url)) {
     stop("wordpress_url is missing")

--- a/R/post.R
+++ b/R/post.R
@@ -95,9 +95,12 @@ Or maybe you forgot to re-start R after editing .Renviron?")
     meta$author, wordpress_url
   )
 
-   post_list <- list( 'date' = meta$date,
+  date <- format(Sys.time(), '%Y-%m-%dT%H:%M:%S')
+  slug <- slugify::slugify(meta$title)
+
+   post_list <- list( 'date' = meta$date %||% date,
                       'title' = meta$title,
-                      'slug' = meta$slug %||% NULL,
+                      'slug' = meta$slug %||% slug,
                       'comment_status' = meta$comment_status %||% "closed",
                       'ping_status' = meta$ping_status %||% "closed",
                       'status' = 'draft',

--- a/inst/rmarkdown/templates/template-name/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/template-name/skeleton/skeleton.Rmd
@@ -1,10 +1,6 @@
 ---
-params:
-  post_title: "The Post Title"
-title: "`r params$post_title`"
-date: "`r format(Sys.time(), '%Y-%m-%dT%H:%M:%S')`"
+title: "The Post Title"
 output: hugodown::md_document
-slug: "`r gsub(' ', '-', tolower(params$post_title))`"
 status: "publish"
 comment_status: "open"
 categories:
@@ -20,7 +16,7 @@ This is a `goodpress` template for writing WordPress post in `R Markdown` format
 
 ## YAML Header
 
-By default, the YAML Header allows you to control the metadata of your post (e.g., `title`, `date`, and `slug`). You may only need to change `post_title`, `categories`, and `tags`.
+By default, the YAML Header allows you to control the metadata of your post (e.g., `title`, `date`, and `slug`). You may only need to provide `title`.
 
 ## Plots, Images, and Videos
 

--- a/inst/rmarkdown/templates/template-name/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/template-name/skeleton/skeleton.Rmd
@@ -1,21 +1,41 @@
 ---
-title: "The post title"
-date: "YYYY-MM-DDTHH:MM:SS"
+params:
+  post_title: "The Post Title"
+title: "`r params$post_title`"
+date: "`r format(Sys.time(), '%Y-%m-%dT%H:%M:%S')`"
 output: hugodown::md_document
+slug: "`r gsub(' ', '-', tolower(params$post_title))`"
 status: "publish"
-slug: "the-post-slug"
+comment_status: "open"
 categories:
   - category1
   - category2
 tags:
-  - R Markdown
-  - goodpress
-  - WordPress
+  - tag1
+  - tag2
+  - tag3
 ---
 
-```{r setup, include=FALSE}
-knitr::opts_chunk$set(echo = TRUE)
-goodpress::set_hooks()
+This is a `goodpress` template for writing WordPress post in `R Markdown` format.
+
+## YAML Header
+
+By default, the YAML Header allows you to control the metadata of your post (e.g., `title`, `date`, and `slug`). You may only need to change `post_title`, `categories`, and `tags`.
+
+## Plots, Images, and Videos
+
+You can include R Plots just as what you normally do:
+
+```{r pressure, fig.cap="Plots from R Code"}
+plot(pressure)
 ```
 
-Refer to [goodpress usage vignette](https://maelle.github.io/goodpress/).
+Or you can add external images like this:
+
+```{r fig.cap="External Images"}
+knitr::include_graphics(file.path("figs", "pressure-1.png"))
+```
+
+Lastly, for videos you can embed them using [vembedr package](https://ijlyttle.github.io/vembedr/articles/vembedr.html).
+
+For more information, please refer to [goodpress usage vignette](https://maelle.github.io/goodpress/).

--- a/inst/rmarkdown/templates/template-name/template.yaml
+++ b/inst/rmarkdown/templates/template-name/template.yaml
@@ -1,4 +1,4 @@
-name: Wordpress Document
+name: WordPress Post Template
 description: >
-   Document for Wordpress
+   Template for WordPress post
 create_dir: FALSE

--- a/man/wp_categories.Rd
+++ b/man/wp_categories.Rd
@@ -17,6 +17,8 @@ This function helps you get your WordPress categories
 details so that you can use for your YAML header.
 }
 \examples{
+\dontrun{
 wordpress_url <- "https://rmd-wordpress.eu" # replace with your own (test) website
 wp_categories(wordpress_url)
+}
 }

--- a/man/wp_tags.Rd
+++ b/man/wp_tags.Rd
@@ -17,6 +17,8 @@ This function helps you get your WordPress tags
 details so that you can use for your YAML header.
 }
 \examples{
+\dontrun{
 wordpress_url <- "https://rmd-wordpress.eu" # replace with your own (test) website
 wp_tags(wordpress_url)
+}
 }


### PR DESCRIPTION
Optimized the rmarkdown template for writing post to save my life.

```
---
params:
  post_title: "The Post Title"
title: "`r params$post_title`"
date: "`r format(Sys.time(), '%Y-%m-%dT%H:%M:%S')`"
output: hugodown::md_document
slug: "`r gsub(' ', '-', tolower(params$post_title))`"
status: "publish"
comment_status: "open"
categories:
  - category1
  - category2
tags:
  - tag1
  - tag2
  - tag3
---
```