### PR TITLE
set pandoc_convert options to wrap=none

### DIFF
--- a/R/post.R
+++ b/R/post.R
@@ -74,7 +74,7 @@ Or maybe you forgot to re-start R after editing .Renviron?")
        to = "html",
        output = html_path,
        wd = getwd(),
-       options = "--mathjax"
+       options = c("--mathjax","--wrap=none")
        )
    )
 


### PR DESCRIPTION
All works beautifully but I noticed that my WordPress posts looked like they had an `<br />` at something like the 70th character, which smacked of pandoc interfering. Indeed, turns out that (on my system at least) pandoc wraps source output by default, meaning that a `<p>` item comes out like this:

```
<p>A lot of our recent work revolves around working with conversational
data, and one thing that’s struck me is that there are no easy ways to
create compelling visualizations. In the ElPaCo project we’re changing
that —stay tuned for updates on <code>rtalk</code>— and here I want to
give a sneak peek into our kitchen.</p>
```
...and on import in WordPress 6.2 those `\n`'s are turned into hard `<br />`'s:
```
<p>A lot of our recent work revolves around working with conversational<br />
  data, and one thing that’s struck me is that there are no easy ways to<br />
  create compelling visualizations. In the ElPaCo project we’re changing<br />
  that —stay tuned for updates on <code>rtalk</code>— and here I want to<br />
```

Fortunately, setting the `pandoc_convert()` options to `wrap=none` solves this, so this is what this pull request does. Solves #36